### PR TITLE
Allow users to set their own image to show when no builds are broken.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Where:
 
 Optional querystring parameters:
 * `projectDisplayNameToStrip`: Normally projects are displayed in the "Project Display Name :: Build Name" syntax. If the leading part is always the same and you want to hide it, you can pass it in here, in a URL encoded format. For example, your project group display name might be "Search Team", but the ID might be "SearchTeam" (no space). You can hide the leading part via: `http://localhost/{teamcity-hostname}/SearchTeam?projectDisplayNameToStrip=Search%20Team`.
-* `successView`: When no builds are failing, the default view is a thumbs up image. This can be overriden to other views: "cats" shows random images of cats.
+* `successView`: When no builds are failing, the default view is a thumbs up image. This can be overriden to other views: "cats" shows random images of cats and "image" can display any image, the URL of which should be passed in via the "imageUrl" querystring parameter.
 
 Heavily blurred screenshot:
 ![Screenshot](docs/teamcity-radiator.png?raw=true "Screenshot")

--- a/routes/builds.js
+++ b/routes/builds.js
@@ -71,6 +71,10 @@ module.exports = function setupRoute(router) {
               case 'cats':
                 res.render('cats', buildStatus);
                 break;
+              case 'image':
+                buildStatus.imageUrl = req.query.imageUrl;
+                res.render('image', buildStatus);
+                break;
               default:
                 res.render('thumbs', buildStatus);
                 break;

--- a/views/image.jade
+++ b/views/image.jade
@@ -1,0 +1,5 @@
+extends layout
+
+block content
+  .center
+    img#thumbs(src="#{imageUrl}")


### PR DESCRIPTION
Added a new view 'image', which shows any image, the URL of which is passed in via the query string - e.g.

http://localhost:3000/teamcity.server/ProjectPrefix/?successView=image&imageUrl=http://www.wiliam.com.au/content/upload/blog/worksonmymachine.jpg
